### PR TITLE
[BUGFIX] Alias VID to ID in Client

### DIFF
--- a/hubspot-ruby.gemspec
+++ b/hubspot-ruby.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency("awesome_print")
   s.add_development_dependency("timecop")
   s.add_development_dependency("guard-rspec")
-  s.add_development_dependency("byebug")
+  s.add_development_dependency("pry")
   s.add_development_dependency("faker")
   s.add_development_dependency("factory_bot")
 end

--- a/lib/hubspot/contact.rb
+++ b/lib/hubspot/contact.rb
@@ -72,7 +72,15 @@ class Hubspot::Contact < Hubspot::Resource
     end
   end
 
-  attr_reader :properties, :vid, :is_new, :is_contact, :list_memberships
+  attr_reader :properties, :is_new, :is_contact, :list_memberships
+
+  def vid
+    @id
+  end
+
+  def vid=(id)
+    @id = id
+  end
 
   def [](property)
     @properties[property]

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,7 +16,7 @@ require 'rspec/its'
 require 'webmock/rspec'
 require 'factory_bot'
 require 'faker'
-require 'byebug'
+require 'pry'
 require 'hubspot-ruby'
 
 # Requires supporting files with custom matchers and macros, etc,


### PR DESCRIPTION
- use pry instead of byebug
- alias vid ot id in client to avoid breaking previous implementations